### PR TITLE
Spanish translation implemented

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,25 +7,27 @@ description 'ESX Boat'
 version '1.0.0'
 
 server_scripts {
-	'@mysql-async/lib/MySQL.lua',
-	'@es_extended/locale.lua',
-	'locales/en.lua',
-	'locales/sv.lua',
-	'config.lua',
-	'server/main.lua'
+    '@mysql-async/lib/MySQL.lua',
+    '@es_extended/locale.lua',
+    'locales/en.lua',
+    'locales/es.lua',
+    'locales/sv.lua',
+    'config.lua',
+    'server/main.lua'
 }
 
 client_scripts {
-	'@es_extended/locale.lua',
-	'locales/en.lua',
-	'locales/fr.lua',
-	'locales/sv.lua',
-	'config.lua',
-	'client/main.lua',
-	'client/marker.lua'
+    '@es_extended/locale.lua',
+    'locales/en.lua',
+    'locales/es.lua',
+    'locales/fr.lua',
+    'locales/sv.lua',
+    'config.lua',
+    'client/main.lua',
+    'client/marker.lua'
 }
 
 dependencies {
-	'es_extended',
-	'esx_vehicleshop'
+    'es_extended',
+    'esx_vehicleshop'
 }

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,0 +1,31 @@
+Locales['es'] = {
+  -- shop
+  ['boat_shop'] = 'Tienda de barcos',
+  ['boat_shop_open'] = 'Pulsa ~INPUT_CONTEXT~ para acceder a la ~y~tienda de barcos~s~.',
+  ['boat_shop_confirm'] = '¿Comprar <span style="color: yellow;">%s</span> por <span style="color: orange;">%s$</span>?',
+  ['boat_shop_bought'] = 'Has ~y~comprado~s~ un ~b~%s~s~ por ~g~%s$~s~',
+  ['boat_shop_nomoney'] = '¡No puedes ~r~permitirte~s~ ese barco!',
+  ['confirm_no'] = 'No',
+  ['confirm_yes'] = 'Si',
+
+  -- garage
+  ['garage'] = 'Garaje de barcos',
+  ['garage_open'] = 'Pulsa ~INPUT_CONTEXT~ para acceder a tu ~y~garaje de barcos~s~',
+  ['garage_store'] = 'Pulsa ~INPUT_CONTEXT~ para ~y~almacenar~s~ el barco en el garaje',
+  ['garage_taken'] = '¡El barco ha sido sacado!',
+  ['garage_stored'] = '¡El barco se ha almacenado en el garaje!',
+  ['garage_noboats'] = '¡No tienes ningún barco guardado! Visita la ~y~tienda de barcos~s~ para comprar uno',
+  ['garage_blocked'] = '¡El barco no ha podido ser sacado, hay un objeto obstruyendo el spawn!',
+  ['garage_notowner'] = '¡No eres el dueño de ese barco!',
+
+  -- license
+  ['license_menu'] = '¿Comprar Licencia de Barcos?',
+  ['license_buy_no'] = 'No',
+  ['license_buy_yes'] = 'Comprar Licencia de Barcos <span style="color: green;">%s$</span>',
+  ['license_bought'] = 'Compraste la ~y~Licencia de Barcos~s~ por ~g~$%s~s~',
+  ['license_nomoney'] = '¡No puedes ~r~permitirte~s~ la ~y~Licencia de Barcos~s~!',
+
+  -- blips
+  ['blip_garage'] = 'Garaje de barcos',
+  ['blip_shop'] = 'Tienda de barcos',
+}

--- a/localization/es_esx_boat.sql
+++ b/localization/es_esx_boat.sql
@@ -1,0 +1,5 @@
+USE `es_extended`;
+
+INSERT INTO `licenses` (`type`, `label`) VALUES
+    ('boat', 'Licencia de Barcos')
+;


### PR DESCRIPTION
Spanish translation implemented in the script.

1250411 - Created the sql `es_esx_boat.sql` with the spanish translation for the database

7b369af - Added the translations of the script in Spanish and fixed the spacing of fxmanifest.lua (4 spaces per tab)