### PR TITLE
Get correct label from config

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -217,10 +217,8 @@ function DeleteSpawnedVehicles()
 end
 
 function getVehicleLabelFromHash(hash)
-	local model = string.lower(GetDisplayNameFromVehicleModel(hash))
-
 	for i=1, #Config.Vehicles, 1 do
-		if Config.Vehicles[i].model == model then
+		if joaat(Config.Vehicles[i].model) == hash then
 			return Config.Vehicles[i].label
 		end
 	end


### PR DESCRIPTION
Fix the issue of the vehicle label not getting correctly. 

Since `GetDisplayNameFromVehicleModel` uses the name from the vehicles.meta and some vehicles like the "seashark", "seashark2", "seashark3" share the same name: "seashark" it won't be able to return the correct vehicle name as listed in the config.

Issue mentioning this: #20 
